### PR TITLE
add keyboard accessibility

### DIFF
--- a/projects/angular-split/src/lib/component/split.component.scss
+++ b/projects/angular-split/src/lib/component/split.component.scss
@@ -8,6 +8,7 @@
   height: 100%;
 
   & > .as-split-gutter {
+    border: none;
     flex-grow: 0;
     flex-shrink: 0;
     background-color: #eeeeee;

--- a/projects/angular-split/src/lib/component/split.component.ts
+++ b/projects/angular-split/src/lib/component/split.component.ts
@@ -524,16 +524,6 @@ export class SplitComponent implements AfterViewInit, OnDestroy {
   }
 
   public startKeyboardDrag(event: KeyboardEvent, gutterOrder: number, gutterNum: number) {
-    switch (event.key) {
-      case 'ArrowLeft':
-      case 'ArrowRight':
-      case 'ArrowUp':
-      case 'ArrowDown':
-          break
-      default:
-          return
-    }
-
     if (this.disabled === true || this.isWaitingClear === true) {
       return
     }

--- a/projects/angular-split/src/lib/utils.ts
+++ b/projects/angular-split/src/lib/utils.ts
@@ -2,7 +2,7 @@ import { ElementRef } from '@angular/core'
 
 import { IArea, IPoint, IAreaSnapshot, ISplitSideAbsorptionCapacity, IAreaAbsorptionCapacity } from './interface'
 
-export function getPointFromEvent(event: MouseEvent | TouchEvent): IPoint {
+export function getPointFromEvent(event: MouseEvent | TouchEvent | KeyboardEvent): IPoint {
   // TouchEvent
   if ((<TouchEvent>event).changedTouches !== undefined && (<TouchEvent>event).changedTouches.length > 0) {
     return {
@@ -17,7 +17,52 @@ export function getPointFromEvent(event: MouseEvent | TouchEvent): IPoint {
       y: (<MouseEvent>event).clientY,
     }
   }
+  // KeyboardEvent
+  else if ((<KeyboardEvent>event).currentTarget !== undefined) {
+    const gutterEl = event.currentTarget as HTMLElement;
+    return {
+      x: gutterEl.offsetLeft,
+      y: gutterEl.offsetTop
+    }
+  }
   return null
+}
+
+export function getKeyboardEndpoint(event: KeyboardEvent, direction: 'horizontal' | 'vertical'): IPoint | null {
+  // Return null if direction keys on the opposite axis were pressed
+  if (direction === 'horizontal') {
+    switch (event.key) {
+      case 'ArrowLeft':
+      case 'ArrowRight':
+          break
+      default:
+          return null
+    }
+  }
+  if (direction === 'vertical') {
+    switch (event.key) {
+      case 'ArrowUp':
+      case 'ArrowDown':
+          break
+      default:
+          return null
+    }
+  }
+
+  const gutterEl = event.currentTarget as HTMLElement
+  let offsetX = gutterEl.offsetLeft, offsetY = gutterEl.offsetTop
+  switch (event.key) {
+      case 'ArrowLeft': offsetX -= 50; break
+      case 'ArrowRight': offsetX += 50; break
+      case 'ArrowUp': offsetY -= 50; break
+      case 'ArrowDown': offsetY += 50; break
+      default: return null
+  }
+
+  return {
+    x: offsetX,
+    y: offsetY
+  }
 }
 
 export function getElementPixelSize(elRef: ElementRef, direction: 'horizontal' | 'vertical'): number {

--- a/projects/angular-split/src/lib/utils.ts
+++ b/projects/angular-split/src/lib/utils.ts
@@ -19,7 +19,7 @@ export function getPointFromEvent(event: MouseEvent | TouchEvent | KeyboardEvent
   }
   // KeyboardEvent
   else if ((<KeyboardEvent>event).currentTarget !== undefined) {
-    const gutterEl = event.currentTarget as HTMLElement;
+    const gutterEl = event.currentTarget as HTMLElement
     return {
       x: gutterEl.offsetLeft,
       y: gutterEl.offsetTop
@@ -50,12 +50,13 @@ export function getKeyboardEndpoint(event: KeyboardEvent, direction: 'horizontal
   }
 
   const gutterEl = event.currentTarget as HTMLElement
+  const offset = 50;
   let offsetX = gutterEl.offsetLeft, offsetY = gutterEl.offsetTop
   switch (event.key) {
-      case 'ArrowLeft': offsetX -= 50; break
-      case 'ArrowRight': offsetX += 50; break
-      case 'ArrowUp': offsetY -= 50; break
-      case 'ArrowDown': offsetY += 50; break
+      case 'ArrowLeft': offsetX -= offset; break
+      case 'ArrowRight': offsetX += offset; break
+      case 'ArrowUp': offsetY -= offset; break
+      case 'ArrowDown': offsetY += offset; break
       default: return null
   }
 


### PR DESCRIPTION
Fixes issue [#98](https://github.com/angular-split/angular-split/issues/98)

1. Changed dragger/ gutter from div to button in template for keyboard focus
2. Added "startKeyboardDrag", which uses new util functions to calculate the start and end points differently from mouse events.
3. Moved chunks of "startMouseDrag" out into separate functions so that keyboard drag can share the code: this.currentlyDragging(), this.drag();, this.stopDragging();

Question: Thoughts on getKeyboardEndpoint doing the "exit early" checks and returning null? Should that be handled by a separate function?

Potential issues discovered while developing:
1. tab order of the gutters is not top-down left-right
2. keyboard resizing does not work while in screenreader mode. However, native HTML sliders don't appear to work either
3. should add a new binding to set an aria label on the gutter. Addressed in #2 

Note: The vertical splits in the demo gif don't have the smooth animation because they don't have a the useTransition animation binding set to true
![split](https://user-images.githubusercontent.com/73202210/96774244-92940e80-139a-11eb-8d4b-855289084b62.gif)
