### PR TITLE
add gutter aria-label

### DIFF
--- a/projects/angular-split/src/lib/component/split.component.ts
+++ b/projects/angular-split/src/lib/component/split.component.ts
@@ -72,6 +72,7 @@ import {
         *ngIf="last === false"
         #gutterEls
         class="as-split-gutter"
+        [attr.aria-label]="gutterAriaLabel"
         [style.flex-basis.px]="gutterSize"
         [style.order]="index * 2 + 1"
         (mousedown)="startDragging($event, index * 2 + 1, index + 1)"
@@ -213,6 +214,10 @@ export class SplitComponent implements AfterViewInit, OnDestroy {
   get gutterDblClickDuration(): number {
     return this._gutterDblClickDuration
   }
+
+  ////
+
+  @Input() gutterAriaLabel: string
 
   ////
 

--- a/src_app/app/component/examples/nested.route.component.ts
+++ b/src_app/app/component/examples/nested.route.component.ts
@@ -12,9 +12,9 @@ import { AComponent } from './AComponent'
     <div class="container">
       <sp-example-title [type]="exampleEnum.NESTED"></sp-example-title>
       <div class="split-example" style="height: 400px;">
-        <as-split direction="horizontal" restrictMove="true" [useTransition]="true">
+        <as-split direction="horizontal" restrictMove="true" [useTransition]="true" gutterAriaLabel="adjustable divider between two main views">
           <as-split-area size="40">
-            <as-split direction="vertical" restrictMove="true">
+            <as-split direction="vertical" restrictMove="true" gutterAriaLabel="adjustable divider within the main left view">
               <as-split-area>
                 <p>
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tiam, quis nostrud
@@ -44,7 +44,7 @@ import { AComponent } from './AComponent'
             </as-split>
           </as-split-area>
           <as-split-area size="60">
-            <as-split direction="vertical" restrictMove="true">
+            <as-split direction="vertical" restrictMove="true" gutterAriaLabel="adjustable divider within the right main view">
               <as-split-area size="25">
                 <p>
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tiam, quis nostrud


### PR DESCRIPTION
Problem: Screenreaders will just read 'group' (or soon to be 'button' if #1 is merged) when focusing on gutters, which is not descriptive.

Solution: Introduce gutterAriaLabel input so that users can provide a descriptive label to assistive technology.

Notes:
 - I did not specify a default label in the component source code because there is no convention established in the original codebase for public-facing text (i.e. internationalization)
 - Before submitting an official PR I will need to update the documentation and examples, but this current PR is just for my team to have this feature available in the shortest time possible.